### PR TITLE
docs: fix brackets in synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,9 @@ Table of Contents
      content_by_lua_block {
         local expr = require("resty.expr.v1")
         local ex = expr.new({
-            {
-                {"arg_name", "==", "json"},
-                {"arg_weight", ">", 10},
-                {"arg_weight", "!", ">", 15},
-            }
+            {"arg_name", "==", "json"},
+            {"arg_weight", ">", 10},
+            {"arg_weight", "!", ">", 15},
         })
 
         -- equal to


### PR DESCRIPTION
Run example code in `Synopsis` got the error below:
```
ERROR: lib/resty/expr/v1.lua:174: attempt to concatenate local 'op' (a table value)
```
Due to the extra brackets in rules for `expr.new`.