### PR TITLE
fix: improve the security of GIT protocol on GitHub and delete the unencrypted git protocol 

### DIFF
--- a/rockspec/lua-resty-expr-main-0-0.rockspec
+++ b/rockspec/lua-resty-expr-main-0-0.rockspec
@@ -1,7 +1,7 @@
 package = "lua-resty-expr-main"
 version = "0-0"
 source = {
-    url = "git://github.com/api7/lua-resty-expr",
+    url = "https://github.com/api7/lua-resty-expr",
     branch = "main",
 }
 


### PR DESCRIPTION
fix:Improve the security of GIT protocol on GitHub and delete the unencrypted git protocol
https://github.blog/2021-09-01-improving-git-protocol-security-github/