### PR TITLE
docs: improved doc on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ Each expression is an array table which has three or four elements:
 }
 ```
 
-Logical operator can be one of
+### Logical Operators
+
+Logical operator can be one of the following:
+
 * OR
 * AND
 * !OR: not (expr1 or expr2 or ...)
 * !AND: not (expr1 and expr2 and ...)
 
-Their combination can be like:
+Example ussage with comparison operators:
 
 ```json
 [
@@ -114,7 +117,7 @@ Their combination can be like:
 
 [Back to TOC](#table-of-contents)
 
-#### Operator List
+### Comparison Operators
 
 |operator|description|example|
 |--------|-----------|-------|

--- a/README.md
+++ b/README.md
@@ -95,40 +95,43 @@ Each expression is an array table which has three or four elements:
 
 #### Comparison Operators
 
-|operator|description|example|
+|**Operator**|**Description**|**Example**|
 |--------|-----------|-------|
-|==      |equal      |{"arg_name", "==", "json"}|
-|~=      |not equal  |{"arg_name", "~=", "json"}|
-|>       |greater than|{"arg_age", ">", 24}|
-|>=      |greater than or equal to|{"arg_age", ">=", 24}|
-|<       |less than  |{"arg_age", "<", 24}|
-|<=      |less than or equal to|{"arg_age", "<=", 24}|
-|~~      |match RegEx, case-sensitive|{"arg_name", "~~", "[a-z]+"}|
-|~*      |match RegEx, case-insensitive|{"arg_name", "~*", "[a-z]+"}|
-|in      |LFS in RHS|{"arg_name", "in", {"1","2"}
-|has     |RHS in LHS|{"graphql_root_fields", "has", "repo"}|
-|!       |reverse the RHS|{"arg_name", "!", "~~", "[a-z]+"}|
-|ipmatch |ip address match|{"remote_addr", "ipmatch", {"127.0.0.1", "192.168.0.0/16"}}|
+|`==`      |equal      |`["arg_version", "==", "v2"]`|
+|`~=`      |not equal  |`["arg_version", "~=", "v2"]`|
+|`>`       |greater than|`["arg_ttl", ">", 3600]`|
+|`>=`      |greater than or equal to|`["arg_ttl", ">=", 3600]`|
+|`<`       |less than  |`["arg_ttl", "<", 3600]`|
+|`<=`      |less than or equal to|`["arg_ttl", "<=", 3600]`|
+|`~~`      |match [RegEx](https://www.pcre.org)|`["arg_env", "~~", "[Dd]ev"]`|
+|`~*`      |match [RegEx](https://www.pcre.org) (case-insensitive) |`["arg_env", "~~", "dev"]`|
+|`in`      |exist in the right-hand side|`["arg_version", "in", ["v1","v2"]]`|
+|`has`     |contain item in the right-hand side|`["graphql_root_fields", "has", "owner"]`|
+|`!`       |reverse the adjacent operator|`["arg_env", "!", "~~", "[Dd]ev"]`|
+|`ipmatch` |match IP address|`["remote_addr", "ipmatch", ["192.168.102.40", "192.168.3.0/24"]]`|
+
 
 [Back to TOC](#table-of-contents)
 
 #### Logical Operators
 
-* OR
-* AND
-* !OR: not (expr1 or expr2 or ...)
-* !AND: not (expr1 and expr2 and ...)
+| **Operator** | **Explanation** |
+|---|---|
+| `AND` | `AND(A,B)` is true if both A and B are true. |
+| `OR` | `OR(A,B)` is true if either A or B is true. |
+| `!AND` | `!AND(A,B)` is true if either A or B is false. |
+| `!OR` | `!OR(A,B)` is true only if both A and B are false. |
 
 Example usage with comparison operators:
 
 ```json
 [
     "AND",
-    ["arg_name", "==", "json"],
+    ["arg_version", "==", "v2"],
     [
-        "!OR",
-        ["arg_weight", ">", 10],
-        ["arg_height", "!", ">", 15]
+        "OR",
+        ["arg_action", "==", "signup"],
+        ["arg_action", "==", "subscribe"]
     ]
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Each expression is an array table which has three or four elements:
 |>=      |greater than or equal to|{"arg_age", ">=", 24}|
 |<       |less than  |{"arg_age", "<", 24}|
 |<=      |less than or equal to|{"arg_age", "<=", 24}|
-|~~      |Regular match|{"arg_name", "~~", "[a-z]+"}|
-|~*      |Case insensitive regular match|{"arg_name", "~*", "[a-z]+"}|
+|~~      |match RegEx|{"arg_name", "~~", "[a-z]+"}|
+|~*      |match RegEx (case-insensitive)|{"arg_name", "~*", "[a-z]+"}|
 |in      |find in array|{"arg_name", "in", {"1","2"}}|
 |has     |left value array has value in the right |{"graphql_root_fields", "has", "repo"}|
 |!       |reverse the result|{"arg_name", "!", "~~", "[a-z]+"}|

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ Each expression is an array table which has three or four elements:
 |>=      |greater than or equal to|{"arg_age", ">=", 24}|
 |<       |less than  |{"arg_age", "<", 24}|
 |<=      |less than or equal to|{"arg_age", "<=", 24}|
-|~~      |match RegEx|{"arg_name", "~~", "[a-z]+"}|
-|~*      |match RegEx (case-insensitive)|{"arg_name", "~*", "[a-z]+"}|
-|in      |find in array|{"arg_name", "in", {"1","2"}}|
-|has     |left value array has value in the right |{"graphql_root_fields", "has", "repo"}|
-|!       |reverse the result|{"arg_name", "!", "~~", "[a-z]+"}|
+|~~      |match RegEx, case-sensitive|{"arg_name", "~~", "[a-z]+"}|
+|~*      |match RegEx, case-insensitive|{"arg_name", "~*", "[a-z]+"}|
+|in      |LFS in RHS|{"arg_name", "in", {"1","2"}
+|has     |RHS in LHS|{"graphql_root_fields", "has", "repo"}|
+|!       |reverse the RHS|{"arg_name", "!", "~~", "[a-z]+"}|
 |ipmatch |ip address match|{"remote_addr", "ipmatch", {"127.0.0.1", "192.168.0.0/16"}}|
 
 [Back to TOC](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Each expression is an array table which has three or four elements:
 |==      |equal      |{"arg_name", "==", "json"}|
 |~=      |not equal  |{"arg_name", "~=", "json"}|
 |>       |greater than|{"arg_age", ">", 24}|
+|>=      |greater than or equal to|{"arg_age", ">=", 24}|
 |<       |less than  |{"arg_age", "<", 24}|
+|<=      |less than or equal to|{"arg_age", "<=", 24}|
 |~~      |Regular match|{"arg_name", "~~", "[a-z]+"}|
 |~*      |Case insensitive regular match|{"arg_name", "~*", "[a-z]+"}|
 |in      |find in array|{"arg_name", "in", {"1","2"}}|
@@ -112,14 +114,12 @@ Each expression is an array table which has three or four elements:
 
 #### Logical Operators
 
-Logical operator can be one of the following:
-
 * OR
 * AND
 * !OR: not (expr1 or expr2 or ...)
 * !AND: not (expr1 and expr2 and ...)
 
-Example ussage with comparison operators:
+Example usage with comparison operators:
 
 ```json
 [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Table of Contents
     * [Synopsis](#synopsis)
     * [Methods](#methods)
         * [new](#new)
-            * [Operator List](#operator-list)
+            * [Operator List](#operator-list)  NEED UPDATE
         * [eval](#eval)
     * [Install](#install)
         * [Compile and install](#compile-and-install)
@@ -92,7 +92,7 @@ Each expression is an array table which has three or four elements:
 }
 ```
 
-### Logical Operators
+#### Logical Operators
 
 Logical operator can be one of the following:
 
@@ -117,7 +117,7 @@ Example ussage with comparison operators:
 
 [Back to TOC](#table-of-contents)
 
-### Comparison Operators
+#### Comparison Operators
 
 |operator|description|example|
 |--------|-----------|-------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Table of Contents
     * [Synopsis](#synopsis)
     * [Methods](#methods)
         * [new](#new)
-            * [Operator List](#operator-list)  NEED UPDATE
+            * [Comparison Operators](#comparison-operators)
+            * [Logical Operators](#logical-operators)
         * [eval](#eval)
     * [Install](#install)
         * [Compile and install](#compile-and-install)
@@ -92,6 +93,23 @@ Each expression is an array table which has three or four elements:
 }
 ```
 
+#### Comparison Operators
+
+|operator|description|example|
+|--------|-----------|-------|
+|==      |equal      |{"arg_name", "==", "json"}|
+|~=      |not equal  |{"arg_name", "~=", "json"}|
+|>       |greater than|{"arg_age", ">", 24}|
+|<       |less than  |{"arg_age", "<", 24}|
+|~~      |Regular match|{"arg_name", "~~", "[a-z]+"}|
+|~*      |Case insensitive regular match|{"arg_name", "~*", "[a-z]+"}|
+|in      |find in array|{"arg_name", "in", {"1","2"}}|
+|has     |left value array has value in the right |{"graphql_root_fields", "has", "repo"}|
+|!       |reverse the result|{"arg_name", "!", "~~", "[a-z]+"}|
+|ipmatch |ip address match|{"remote_addr", "ipmatch", {"127.0.0.1", "192.168.0.0/16"}}|
+
+[Back to TOC](#table-of-contents)
+
 #### Logical Operators
 
 Logical operator can be one of the following:
@@ -114,23 +132,6 @@ Example ussage with comparison operators:
     ]
 ]
 ```
-
-[Back to TOC](#table-of-contents)
-
-#### Comparison Operators
-
-|operator|description|example|
-|--------|-----------|-------|
-|==      |equal      |{"arg_name", "==", "json"}|
-|~=      |not equal  |{"arg_name", "~=", "json"}|
-|>       |greater than|{"arg_age", ">", 24}|
-|<       |less than  |{"arg_age", "<", 24}|
-|~~      |Regular match|{"arg_name", "~~", "[a-z]+"}|
-|~*      |Case insensitive regular match|{"arg_name", "~*", "[a-z]+"}|
-|in      |find in array|{"arg_name", "in", {"1","2"}}|
-|has     |left value array has value in the right |{"graphql_root_fields", "has", "repo"}|
-|!       |reverse the result|{"arg_name", "!", "~~", "[a-z]+"}|
-|ipmatch |ip address match|{"remote_addr", "ipmatch", {"127.0.0.1", "192.168.0.0/16"}}|
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
Reading this repo today for a new doc. Happened to spot a few things in README and here's a proposal for improvement. 

In README:
* added `>=` and `<=`
* added title name for comparison operators
* adjusted the section order slightly to flow better